### PR TITLE
Fix Python 3 incompatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 .DS_Store
 .pypirc
 env/*
+pyscribe_log.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "2.7"
+  - "3.4"
 # command to install dependencies
 install: "pip install -r requirements.txt"
 # command to run tests

--- a/pyscribe/pyscribe.py
+++ b/pyscribe/pyscribe.py
@@ -332,8 +332,8 @@ class Runner(object):
     def watch(self, line, line_num, program_file, program_ast):
         variable_id, variable_type = utils.get_id_and_type(line, program_ast)
         self.watcher.watch_var(variable_id)
-        lines = filter(lambda x: x > line_num,
-                       utils.lines_variable_changed(variable_id, program_file))
+        lines = list(filter(lambda x: x > line_num,
+                       utils.lines_variable_changed(variable_id, program_file)))
         self.watcher.set_lines(variable_id, lines)
         return ("Watching variable " +
                 variable_id +

--- a/pyscribe/utils.py
+++ b/pyscribe/utils.py
@@ -3,7 +3,7 @@ import re
 
 def draw_line(unit="-"):
     output = ""
-    for _ in xrange(40):
+    for _ in range(40):
         output += unit
     return output + "\\n"
 

--- a/pyscribe_log.txt
+++ b/pyscribe_log.txt
@@ -1,3 +1,0 @@
-From line 4: Watching variable x, currently int 5
-From line 5: x changed to 3
-From line 7: x changed to 7

--- a/tests/comp/basic.py
+++ b/tests/comp/basic.py
@@ -7,7 +7,7 @@ def main():
     ps.p(x)
 
     bar = "foo"
-    for i in xrange(5):
+    for i in range(5):
         bar += str(i)
         ps.iterscribe(bar)
 


### PR DESCRIPTION
There were only a few minor things that needed to be done, as it turned out, to get PyScribe to work with Python 3. I also added pyscribe_log.txt to the gitignore, as it didn't look like it was supposed to actually be there.

Refs #2 