### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ This log comes from running the desugared version of test.py:
 import re
 import pprint
 import datetime
-#from pyscribe import pyscribe
+# from pyscribe import pyscribe
 
 def main():
     pyscribe_log = open('pyscribe_logs.txt', 'w')


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
